### PR TITLE
support external references without file extension

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -170,10 +170,11 @@ module.exports = {
                                 }
                             }
 
-                            //find internal and external refrences
-                            if (line.match(/<<[^]*?>>/g) && !line.startsWith('//')) {
+                            //find internal and external references
+                            if (line.match(/<<[^\>]+>>/g) && !line.startsWith('//')) {
+
                                 //console.log("LINE-----",line)
-                                var extractLink = line.match(/<<[^]*?>>/g); //there may be more than one matching items
+                                var extractLink = line.match(/<<[^\>]+>>/g); //there may be more than one matching items
                                 for (var i = 0; i < extractLink.length; i++) {
                                     var newReference = extractLink[i];
                                     newReference = newReference.slice(2);
@@ -185,7 +186,10 @@ module.exports = {
                                     }
 
                                     //seperate internal and external refrences
-                                    if (newReference.includes('.adoc')) {
+                                    if (newReference.includes('.adoc') || newReference.includes('#')) {
+
+                                        newReference = newReference.replace(/(\.adoc)?#?$/, ".adoc");
+
                                         //external refrence
                                         try {
                                             var levels = newReference.match(/(\.\.\/)/g).length;
@@ -195,7 +199,6 @@ module.exports = {
                                                 //console.log("BEFORE: "+newReference);
                                                 newReference = newReference.slice(3)
                                                 tempDir = path.resolve(tempDir, '../');
-
 
                                                 if ((l + 1) === levels) {
                                                     newReference = tempDir + "/" + newReference;


### PR DESCRIPTION
Add support for the following type of inter-document cross references:
<<document-b.adoc#,Section B>>
<<document-b#,Section B>>  (without the optional extension)
<<document-b.adoc,Section B>> (without the # sign)

(see https://asciidoctor.org/docs/user-manual/#inter-document-cross-references)