### PR TITLE
handling of external reference path

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -256,29 +256,7 @@ module.exports = {
                   //seperate internal and external refrences
                   if (link.includes(".adoc")) {
                     //external refrence
-                    try {
-                      var levels = link.match(/(\.\.\/)/g).length;
-                      var tempDir = folderPath;
-
-                      for (var l = 0; l < levels; l++) {
-                        //console.log("BEFORE: "+link);
-                        link = link.slice(3);
-                        tempDir = path.resolve(tempDir, "../");
-
-                        if (l + 1 === levels) {
-                          link = tempDir + "/" + link;
-                          //console.log("FINAL LINK TO CHECK: : : : : : :", link)
-                        }
-                      }
-                    } catch (error) {
-                      //console.log("ERROR: " + error);
-                      if (link.match(/\.\//g)) {
-                        link = link.slice(2);
-                        link = folderPath + link;
-                      }
-                    }
-                    //console.log("EXTERNAL REF: " + link);
-                    externalLinks.push(link);
+                    externalLinks.push(path.resolve(folderPath, link));
                   } else {
                     //internal refrence
                     internalRef.push(link);


### PR DESCRIPTION
This improvements applies to `xref:xxx[yyy]` and is simlilar to the one for  `<<file.adoc#anchor>>` (see #5)

The proposed implementation simplifies the algorithm and solves 1 issue
- From my understanding path.resolve() provides a robust way of resolving the path. So there should be no need of a special handling of "../" or "./".
- In case the external reference starts is something like <<some/file.adoc#>> (i.e. it does not start with "../" or "./"), the reference check failed. This should work now.