### PR TITLE
consider case of <<file.adoc#>> without an anchor after the #

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -232,6 +232,8 @@ module.exports = {
                       newReference = newReference.replace(/#/, ".adoc#");
                       //console.log("After MOD: ", newReference);
                     }
+                    // remaove the "#" if it is not followed by an anchor
+                    newReference = newReference.replace(/#$/, "");
                     //external refrence
                     externalLinks.push(path.resolve(folderPath, newReference));
                   } else {


### PR DESCRIPTION
This solves an issue that occurred if the `#` is not followed by an anchor name.
In this case the tool previously returned an error message saying that the empty anchor `` was not found in the target file