### PR TITLE
Add support for recursice check in from treeView

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -63,57 +63,113 @@ function registerAnchor(anchorArray, newAnchor) {
   }
 }
 
+function getTreeViewPath() {
+  var treeView
+  if (atom.packages.isPackageLoaded("tree-view")) {
+    treeView = atom.packages.getLoadedPackage("tree-view")
+    treeView = treeView.mainModule.treeView
+    return treeView.selectedPath
+  } else {
+    atom.notifications.addError('Cannot get reference to tree-view')
+    return null
+  }
+}
+
 module.exports = {
-  activate: function() {
-    atom.contextMenu.add({
-      "atom-text-editor": [
-        {
-          label: "Check References",
-          command: "asciidoc-reference-check:checkReference"
-        }
-      ]
+    activate: function () {
+
+        atom.commands.add('atom-text-editor', {
+            'asciidoc-reference-check:checkReferenceFromEditor': checkReferencesFromEditor
+        });
+        atom.commands.add('.tree-view', {
+            'asciidoc-reference-check:checkReferenceFromTreeViewFile': checkReferencesFromTreeViewFile
+        });
+        atom.commands.add('.tree-view', {
+            'asciidoc-reference-check:checkReferenceFromTreeViewFolder': checkReferencesFromTreeViewFolder
+        });
+    }
+};
+
+
+function checkReferencesFromEditor(event) {
+  var ref
+  if ((ref = atom.workspace.getActiveTextEditor()) != null) {
+    checkReferences(ref.getPath());
+  } else {
+    atom.notifications.addError('Cannot get reference to Atom Editor')
+  }
+}
+
+function checkReferencesFromTreeViewFile(event) {
+  checkReferences(getTreeViewPath())
+}
+
+function checkReferencesFromTreeViewFolder(event) {
+
+  var walk = function(dir) {
+      var results = [];
+      var list = fs.readdirSync(dir);
+      list.forEach(function(file) {
+          file = dir + '/' + file;
+          var stat = fs.statSync(file);
+          if (stat && stat.isDirectory()) {
+              /* Recurse into a subdirectory */
+              results = results.concat(walk(file));
+          } else {
+              /* Is a file */
+              var file_type = file.split(".").pop();
+              if (file_type == "adoc") {
+                results.push(file);
+              }
+          }
+      });
+      return results;
+  }
+
+
+  var fileList = walk(getTreeViewPath());
+  var numberFiles = fileList.length;
+
+  for (var i = 0; i < numberFiles; i++) {
+    checkReferences(fileList[i])
+  }
+}
+
+// check the references for the current file
+function checkReferences(filePath) {
+
+    var allGood = true;
+
+    var folderPath;
+
+    //to hold anchors
+    var anchorArray = [];
+
+    //to hold internal references
+    var internalRef = [];
+
+    //to hold external references
+    var externalRef = [];
+
+    //to hold external links
+    var externalLinks = [];
+
+    //get directory
+    folderPath = path.parse(filePath).dir;
+    //console.log('Running for: ' + fileName);
+    //console.log('Directory: ', folderPath)
+
+    //lets read file contents line by line
+    //we are not reading the file from editor, but instead the file from disk
+    var reader = new readl(filePath, {
+        encoding: 'utf8',
+        emptyLines: 'true'
     });
 
-    atom.commands.add("atom-text-editor", {
-      "asciidoc-reference-check:checkReference": function(event) {
-        var allGood = true;
-
-        var folderPath;
-
-        //to hold anchors
-        var anchorArray = [];
-
-        //to hold internal references
-        var internalRef = [];
-
-        //to hold external references
-        var externalRef = [];
-
-        //to hold external links
-        var externalLinks = [];
-
-        //get active file from atom editor
-        var ref;
-        if ((ref = atom.workspace.getActiveTextEditor()) != null) {
-          // /ref.getPath();
-          //console.log(ref.getPath());
-          var fileName = ref.getPath();
-          //get directory
-          folderPath = path.parse(fileName).dir;
-          //console.log('Running for: ' + fileName);
-          //console.log('Directory: ', folderPath)
-
-          //lets read file contents line by line
-          //we are not reading the file from editor, but instead the file from disk
-          var reader = new readl(fileName, {
-            encoding: "utf8",
-            emptyLines: "true"
-          });
-
-          //Emit this function when one line is read:
-          reader.on("line", function(line, index, start, end) {
-            //read file line by line
-            //ignore everything inside comment blocks
+    //Emit this function when one line is read:
+    reader.on('line', function (line, index, start, end) {
+        //read file line by line
+        //ignore everything inside comment blocks
 
             if (line.startsWith("////")) {
               if (!insideCommentBlock) {
@@ -243,8 +299,8 @@ module.exports = {
                 }
               }
 
-              //find internal and external refrences
               if (line.match(substring) && !line.startsWith("//")) {
+            //find internal and external refrences with format xref:link[text]
                 //console.log("LINE: " + line);
                 var tempLinksArr = line.match(/(xref:)[^]*?\[/g);
                 //console.log("templinksarr: " + tempLinksArr)
@@ -447,10 +503,5 @@ module.exports = {
 
           //Start reading the file
           reader.read();
-        } else {
-          atom.notifications.addError("Cannot get reference to Atom Editor");
-        }
-      }
-    });
-  }
-};
+
+}

--- a/menus/asciidoc-reference-check.cson
+++ b/menus/asciidoc-reference-check.cson
@@ -1,0 +1,20 @@
+# See https://atom.io/docs/latest/creating-a-package#menus for more details
+"context-menu":
+  "atom-text-editor": [
+    {
+      "label": "Check References"
+      "command": "asciidoc-reference-check:checkReferenceFromEditor"
+    }
+  ],
+  ".tree-view .file .name[data-name$=\\.adoc]": [
+    {
+      "label": "Check References"
+      "command": "asciidoc-reference-check:checkReferenceFromTreeViewFile"
+    }
+  ],
+  ".tree-view .directory .header .name": [
+    {
+      "label": "Check References"
+      "command": "asciidoc-reference-check:checkReferenceFromTreeViewFolder"
+    }
+  ]


### PR DESCRIPTION
This commit introduces a feature to launch check from the treeView, both for single adoc files, a well as for folders (in the latter case it performs a recursive check of all adoc files in the folder and subfolders)

Note that error notifications still need to be improved in order to be able to clearly identify in which file a error has been detected (this can be added later)