### PR TITLE
Solve issue "extractLink.length" undefined

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -128,8 +128,8 @@ module.exports = {
             //to only check for refrences which are not in commented section
             if (!insideCommentBlock) {
               //find if line contains an anchor with format [[anchor]] or [[anchor, something]]
-              if (line.match(/[^\[\[][^]*?\]\]/g) && !line.startsWith("//")) {
-                var extractLink = line.match(/\[\[[^]*?\]\]/g);
+              if (line.match(/\[\[[^\]]+\]\]/g) && !line.startsWith("//")) {
+                var extractLink = line.match(/\[\[[^\]]+\]\]/g);
                 //console.log("LINE: "+ line);
                 //console.log("EXTRACT LINK: "+ extractLink);
                 for (var i = 0; i < extractLink.length; i++) {


### PR DESCRIPTION
Solve an issue leading to extractLink.length undefined error in some cases.
In some case the if condition matched, but not the line.match, so that extractLink was null