### PR TITLE
Add support for recursive check

### DIFF
--- a/lib/asciidoc-reference-check.js
+++ b/lib/asciidoc-reference-check.js
@@ -51,11 +51,29 @@ function uniq(a) {
   });
 }
 
+// get the path of the item selected in treeView
+function getTreeViewPath() {
+  if (!atom.packages.isPackageLoaded('tree-view')) {
+    atom.notifications.addError('Cannot get reference to tree-view');
+    return null;
+  }
+
+  var treeView = atom.packages.getLoadedPackage('tree-view');
+  treeView = treeView.mainModule.treeView;
+  return treeView.selectedPath;
+}
+
 // map commands
 module.exports = {
   activate: function () {
     atom.commands.add('atom-text-editor', {
       'asciidoc-reference-check:checkReferenceFromEditor': checkReferencesFromEditor,
+    });
+    atom.commands.add('.tree-view', {
+      'asciidoc-reference-check:checkReferenceFromTreeViewFile': checkReferencesFromTreeViewFile,
+    });
+    atom.commands.add('.tree-view', {
+      'asciidoc-reference-check:checkReferenceFromTreeViewFolder': checkReferencesFromTreeViewFolder,
     });
   },
 };
@@ -70,8 +88,55 @@ function checkReferencesFromEditor(event) {
   }
 }
 
+// check the current file selected in the treeView
+function checkReferencesFromTreeViewFile(event) {
+  checkReferences(getTreeViewPath());
+}
+
+// check recursively the current folder selected in the treeView
+function checkReferencesFromTreeViewFolder(event) {
+
+  //walk recursively through the folder and returns file list
+  function walk(dir) {
+    var results = [];
+    var list = fs.readdirSync(dir);
+    list.forEach(file => {
+      file = dir + '/' + file;
+      var stat = fs.statSync(file);
+      if (stat && stat.isDirectory()) {
+        /* Recurse into a subdirectory */
+        results = results.concat(walk(file));
+      } else {
+        /* Is a file */
+        var fileType = file.split('.').pop();
+        if (fileType === 'adoc') {
+          results.push(file);
+        }
+      }
+    });
+
+    return results;
+  }
+
+  var pathTreeView = getTreeViewPath();
+  var fileList = walk(pathTreeView);
+  var numberFiles = fileList.length;
+
+  var fileListShort = '';
+  fileList.forEach(file =>  {
+    fileListShort += path.relative(pathTreeView, file) + ', ';
+  });
+  atom.notifications.addInfo(
+    'Checking: `' + fileListShort + '`'
+  );
+
+  for (let i = 0; i < numberFiles; i++) {
+    checkReferences(fileList[i], pathTreeView);
+  }
+}
+
 // check the references contained in the file
-// basePath is a shorter version of the filePath that wil be used in log messages
+// basePath is a shorter version of the filePath that will be used in log messages
 function checkReferences(filePath, basePath) {
 
   // string identifying the current file in any log message
@@ -326,14 +391,14 @@ function checkReferences(filePath, basePath) {
         '`' + logMsgFilePath + '`: No internal reference found.'
       );
     } else if (notFoundInternal[0] == null) {
-        atom.notifications.addSuccess(
-          '`' + logMsgFilePath + '`: All internal references are `OK`.'
-        );
+      atom.notifications.addSuccess(
+        '`' + logMsgFilePath + '`: All internal references are `OK`.'
+      );
     } else {
       notFoundInternal.forEach(function (it) {
         //console.log('Cannot find the anchor: ' + it + ' in current file.');
         atom.notifications.addError(
-          '`' + logMsgFilePath + '`: Cannot find anchor: `' + it + '` in current file.',
+          '`' + logMsgFilePath + '`: Cannot find anchor: `' + it + '`.',
           {
             dismissable: true,
           }
@@ -343,8 +408,8 @@ function checkReferences(filePath, basePath) {
 
     //check al external references
     if (externalRefs[0] == null) {
-        atom.notifications.addSuccess(
-          '`' + logMsgFilePath + '`: No external reference found.');
+      atom.notifications.addSuccess(
+        '`' + logMsgFilePath + '`: No external reference found.');
     } else {
       //get uniques so that we only check them once
       externalRefs = uniq(externalRefs);

--- a/menus/asciidoc-reference-check.cson
+++ b/menus/asciidoc-reference-check.cson
@@ -5,4 +5,16 @@
       "label": "Check References"
       "command": "asciidoc-reference-check:checkReferenceFromEditor"
     }
+  ],
+  ".tree-view .file .name[data-name$=\\.adoc]": [
+    {
+      "label": "Check References"
+      "command": "asciidoc-reference-check:checkReferenceFromTreeViewFile"
+    }
+  ],
+  ".tree-view .directory .header .name": [
+    {
+      "label": "Check References"
+      "command": "asciidoc-reference-check:checkReferenceFromTreeViewFolder"
+    }
   ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "activationEvents": [
     "asciidoc-reference-check:checkReference"
   ],
-  "author": "Gaurav Nelson",
+  "author": "Gaurav Nelson & Julien Pfefferkorn",
   "bugs": "https://github.com/gaurav-nelson/asciidoc-reference-check/issues",
   "repository": "https://github.com/gaurav-nelson/asciidoc-reference-check",
   "license": "MIT",


### PR DESCRIPTION
Add a dropdown menu item in treeView to trigger recursive check of all adoc files in a folder and in its subfolders recursively